### PR TITLE
Issue 23/trapezoidal estimation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "function": "^0.6.1",
         "function-plot": "^1.23.2",
         "joi": "^17.9.2",
+        "mathjax": "^3.2.2",
         "mathjs": "^11.8.0",
         "plot": "^1.0.22",
         "prop-types": "^15.8.1",
@@ -13548,6 +13549,11 @@
         "extend": "^3.0.0",
         "mr-parser": "^0.2.1"
       }
+    },
+    "node_modules/mathjax": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/mathjax/-/mathjax-3.2.2.tgz",
+      "integrity": "sha512-Bt+SSVU8eBG27zChVewOicYs7Xsdt40qm4+UpHyX7k0/O9NliPc+x77k1/FEsPsjKPZGJvtRZM1vO+geW0OhGw=="
     },
     "node_modules/mathjs": {
       "version": "11.8.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "function": "^0.6.1",
     "function-plot": "^1.23.2",
     "joi": "^17.9.2",
+    "mathjax": "^3.2.2",
     "mathjs": "^11.8.0",
     "plot": "^1.0.22",
     "prop-types": "^15.8.1",

--- a/public/index.html
+++ b/public/index.html
@@ -24,6 +24,8 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+    <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <title>React App</title>
   </head>
   <body>

--- a/src/components/calculator/Estimation.jsx
+++ b/src/components/calculator/Estimation.jsx
@@ -1,7 +1,12 @@
 import React from 'react';
+import LaTex from './Latex';
 
 function Estimation() {
-    return <div>Estimate: </div>;
+    return (
+        <div className="Formula">
+            <LaTex tex="f(x) = e^{x}" />
+        </div>
+    );
 }
 
 export default Estimation;

--- a/src/components/calculator/Estimation.jsx
+++ b/src/components/calculator/Estimation.jsx
@@ -18,7 +18,7 @@ function MethodSwitch() {
             case integrationMethods.MIDPOINT_RULE:
                 return <>Midpoint Integration</>;
             case integrationMethods.TRAPEZOIDAL_RULE:
-                return TrapezodialEstimation();
+                return TrapezodialEstimation('x^2', 0, 2, 3);
             case integrationMethods.SIMPSON_RULE:
                 return <>Simpson</>;
             default:

--- a/src/components/calculator/Estimation.jsx
+++ b/src/components/calculator/Estimation.jsx
@@ -18,7 +18,7 @@ function MethodSwitch() {
             case integrationMethods.MIDPOINT_RULE:
                 return <>Midpoint Integration</>;
             case integrationMethods.TRAPEZOIDAL_RULE:
-                return TrapezodialEstimation('x^2', 0, 2, 3);
+                return TrapezodialEstimation('sin(x)', 0, Math.PI, 10);
             case integrationMethods.SIMPSON_RULE:
                 return <>Simpson</>;
             default:

--- a/src/components/calculator/Estimation.jsx
+++ b/src/components/calculator/Estimation.jsx
@@ -1,12 +1,35 @@
 import React from 'react';
-import LaTex from './Latex';
+import useCalculatorState from '../../hooks/useCalculatorState';
+import {
+    differentiationMethods,
+    integrationMethods,
+} from '../../context/constants';
+import TrapezodialEstimation from './TrapezoidalEstimation';
+
+function MethodSwitch() {
+    const [state] = useCalculatorState();
+
+    function forMethod() {
+        switch (state.method) {
+            case differentiationMethods.MIDDLE_POINT:
+                return <>Midpoint Differentiation</>;
+            case differentiationMethods.LAGRANGE_POLYNOMIAL_THREE_POINT:
+                return <>Lagrange</>;
+            case integrationMethods.MIDPOINT_RULE:
+                return <>Midpoint Integration</>;
+            case integrationMethods.TRAPEZOIDAL_RULE:
+                return TrapezodialEstimation();
+            case integrationMethods.SIMPSON_RULE:
+                return <>Simpson</>;
+            default:
+                return null;
+        }
+    }
+    return forMethod();
+}
 
 function Estimation() {
-    return (
-        <div className="Formula">
-            <LaTex tex="f(x) = e^{x}" />
-        </div>
-    );
+    return MethodSwitch();
 }
 
 export default Estimation;

--- a/src/components/calculator/Latex.jsx
+++ b/src/components/calculator/Latex.jsx
@@ -1,0 +1,20 @@
+import React, { useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
+
+function LaTex({ tex }) {
+    const mathRef = useRef();
+
+    useEffect(() => {
+        if (window.MathJax) {
+            window.MathJax.typesetPromise([mathRef.current]);
+        }
+    }, [tex]);
+
+    return <div ref={mathRef}>{`\\(${tex}\\)`}</div>;
+}
+
+LaTex.propTypes = {
+    tex: PropTypes.string.isRequired,
+};
+
+export default LaTex;

--- a/src/components/calculator/TrapezoidalEstimation.jsx
+++ b/src/components/calculator/TrapezoidalEstimation.jsx
@@ -2,21 +2,7 @@ import React from 'react';
 import trapezoidal from '../../lib/trapezoidal';
 import LaTex from './Latex';
 
-function LatexString(
-    func,
-    x0,
-    x1,
-    x2,
-    xn,
-    h,
-    interval,
-    estimation,
-    latexString,
-) {
-    let latex = latexString;
-    if (interval <= 3) {
-        latex = `\\scriptsize\\int_{${x0}}^{${xn}}f(x)dx\\approx\\frac{(${xn}-${x0})}{${h}}\\left[f(${x0})+2f(${x1})+2f(${x2})+f(${xn})\\right]`;
-    }
+function LatexString(func, estimation, latexString) {
     return (
         <div className="Estimation">
             <p>Formula</p>
@@ -29,47 +15,16 @@ function LatexString(
             <LaTex tex="\tiny\int_{a}^{b}f(x)dx\approx\frac{(b-a)}{2n}\left[f(x_{0})+2f(x_{1})+2f(x_{2})+\cdots +2f(x_{n-1})+f(x_{n})\right]" />
             <br />
             <p>Actual Estimation</p>
-            <LaTex tex={latex} />
+            <LaTex tex={latexString} />
         </div>
     );
 }
 
-function PIString(
-    piAtStart,
-    func,
-    x0,
-    x1,
-    x2,
-    xn,
-    h,
-    interval,
-    estimation,
-    latexString,
-) {
+function PIString(piAtStart, func, estimation, latexString) {
     if (piAtStart === true) {
-        return LatexString(
-            func,
-            x0,
-            x1,
-            x2,
-            xn,
-            h,
-            interval,
-            estimation,
-            latexString,
-        );
+        return LatexString(func, estimation, latexString);
     }
-    return LatexString(
-        func,
-        x0,
-        x1,
-        x2,
-        xn,
-        h,
-        interval,
-        estimation,
-        latexString,
-    );
+    return LatexString(func, estimation, latexString);
 }
 
 function TrapezodialEstimation(func, xStart, xEnd, interval) {
@@ -83,39 +38,27 @@ function TrapezodialEstimation(func, xStart, xEnd, interval) {
     const x2 = (xEnd - delta).toFixed(1);
 
     let latexString = `\\scriptsize\\int_{${x0}}^{${xn}}f(x)dx\\approx\\frac{(${xn}-${x0})}{${h}}\\left[f(${x0})+2f(${x1})+\\cdots +2f(${x2})+f(${xn})\\right]`;
+    if (interval <= 3) {
+        latexString = `\\scriptsize\\int_{${x0}}^{${xn}}f(x)dx\\approx\\frac{(${xn}-${x0})}{${h}}\\left[f(${x0})+2f(${x1})+2f(${x2})+f(${xn})\\right]`;
+    }
     let isPI = false;
 
     if (xStart !== Math.PI && xEnd !== Math.PI) {
-        return LatexString(
-            func,
-            x0,
-            x1,
-            x2,
-            xn,
-            h,
-            interval,
-            estimation,
-            latexString,
-        );
+        return LatexString(func, estimation, latexString);
     }
     if (xStart === Math.PI) {
         latexString = `\\scriptsize\\int_{\\pi}^{${xn}}f(x)dx\\approx\\frac{(${xn}-\\pi)}{${h}}\\left[f(\\pi)+2f(${x1})+\\cdots +2f(${x2})+f(${xn})\\right]`;
+        if (interval <= 3) {
+            latexString = `\\scriptsize\\int_{\\pi}^{${xn}}f(x)dx\\approx\\frac{(${xn}-\\pi)}{${h}}\\left[f(\\pi)+2f(${x1})+2f(${x2})+f(${xn})\\right]`;
+        }
         isPI = true;
     } else if (xEnd === Math.PI) {
         latexString = `\\scriptsize\\int_{${x0}}^{\\pi}f(x)dx\\approx\\frac{(\\pi-${x0})}{${h}}\\left[f(${x0})+2f(${x1})+\\cdots +2f(${x2})+f(\\pi)\\right]`;
+        if (interval <= 3) {
+            latexString = `\\scriptsize\\int_{${x0}}^{\\pi}f(x)dx\\approx\\frac{(\\pi-${x0})}{${h}}\\left[f(${x0})+2f(${x1})+2f(${x2})+f(\\pi)\\right]`;
+        }
     }
-    return PIString(
-        isPI,
-        func,
-        x0,
-        x1,
-        x2,
-        xn,
-        h,
-        interval,
-        estimation,
-        latexString,
-    );
+    return PIString(isPI, func, estimation, latexString);
 }
 
 export default TrapezodialEstimation;

--- a/src/components/calculator/TrapezoidalEstimation.jsx
+++ b/src/components/calculator/TrapezoidalEstimation.jsx
@@ -5,16 +5,48 @@ import LaTex from './Latex';
 function TrapezodialEstimation(func, xStart, xEnd, interval) {
     const estimation = trapezoidal(func, xStart, xEnd, interval).toFixed(6);
 
+    const x0 = (xStart + 0).toFixed(0);
+    const xn = (xEnd + 0).toFixed(0);
+    const delta = (xEnd - xStart) / interval;
+    const h = 2 * interval;
+    const x1 = (xStart + delta).toFixed(1);
+    const x2 = (xEnd - delta).toFixed(1);
+
+    if (interval > 3) {
+        const latexString = `\\scriptsize\\int_{${x0}}^{${xn}}f(x)dx\\approx\\frac{(${xn}-${x0})}{${h}}\\left[f(${x0})+2f(${x1})+\\cdots +2f(${x2})+f(${xn})\\right]`;
+
+        return (
+            <div className="Estimation">
+                <p>Formula</p>
+                <LaTex tex={func} />
+                <br />
+                <p>Estimation</p>
+                <LaTex tex={estimation} />
+                <br />
+                <p>Quadrature Function</p>
+                <LaTex tex="\tiny\int_{a}^{b}f(x)dx\approx\frac{(b-a)}{2n}\left[f(x_{0})+2f(x_{1})+2f(x_{2})+\cdots +2f(x_{n-1})+f(x_{n})\right]" />
+                <br />
+                <p>Actual Estimation</p>
+                <LaTex tex={latexString} />
+            </div>
+        );
+    }
+
+    const latexString = `\\scriptsize\\int_{${x0}}^{${xn}}f(x)dx\\approx\\frac{(${xn}-${x0})}{${h}}\\left[f(${x0})+2f(${x1})+2f(${x2})+f(${xn})\\right]`;
+
     return (
         <div className="Estimation">
-            <p1>Formula</p1>
+            <p>Formula</p>
             <LaTex tex={func} />
             <br />
-            <p1>Estimation</p1>
+            <p>Estimation</p>
             <LaTex tex={estimation} />
             <br />
-            <p1>Quadrature Function</p1>
-            <LaTex tex="\small \int_{x1}^{x3}f(x)dx \approx \frac{1}{3}h(f(x_{1}) + 4f(x_{2}) + f(x_{3}))" />
+            <p>Quadrature Function</p>
+            <LaTex tex="\tiny\int_{a}^{b}f(x)dx\approx\frac{(b-a)}{2n}\left[f(x_{0})+2f(x_{1})+2f(x_{2})+\cdots +2f(x_{n-1})+f(x_{n})\right]" />
+            <br />
+            <p>Actual Estimation</p>
+            <LaTex tex={latexString} />
         </div>
     );
 }

--- a/src/components/calculator/TrapezoidalEstimation.jsx
+++ b/src/components/calculator/TrapezoidalEstimation.jsx
@@ -1,10 +1,20 @@
 import React from 'react';
+import trapezoidal from '../../lib/trapezoidal';
 import LaTex from './Latex';
 
-function TrapezodialEstimation() {
+function TrapezodialEstimation(func, xStart, xEnd, interval) {
+    const estimation = trapezoidal(func, xStart, xEnd, interval).toFixed(6);
+
     return (
-        <div className="Formula">
-            <LaTex tex="f(x) = e^{x}" />
+        <div className="Estimation">
+            <p1>Formula</p1>
+            <LaTex tex={func} />
+            <br />
+            <p1>Estimation</p1>
+            <LaTex tex={estimation} />
+            <br />
+            <p1>Quadrature Function</p1>
+            <LaTex tex="\small \int_{x1}^{x3}f(x)dx \approx \frac{1}{3}h(f(x_{1}) + 4f(x_{2}) + f(x_{3}))" />
         </div>
     );
 }

--- a/src/components/calculator/TrapezoidalEstimation.jsx
+++ b/src/components/calculator/TrapezoidalEstimation.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import LaTex from './Latex';
+
+function TrapezodialEstimation() {
+    return (
+        <div className="Formula">
+            <LaTex tex="f(x) = e^{x}" />
+        </div>
+    );
+}
+
+export default TrapezodialEstimation;

--- a/src/components/calculator/TrapezoidalEstimation.jsx
+++ b/src/components/calculator/TrapezoidalEstimation.jsx
@@ -2,19 +2,18 @@ import React from 'react';
 import trapezoidal from '../../lib/trapezoidal';
 import LaTex from './Latex';
 
-function TrapezodialEstimation(func, xStart, xEnd, interval) {
-    const estimation = trapezoidal(func, xStart, xEnd, interval).toFixed(6);
-
-    const x0 = (xStart + 0).toFixed(0);
-    const xn = (xEnd + 0).toFixed(0);
-    const delta = (xEnd - xStart) / interval;
-    const h = 2 * interval;
-    const x1 = (xStart + delta).toFixed(1);
-    const x2 = (xEnd - delta).toFixed(1);
-
+function LatexString(
+    func,
+    x0,
+    x1,
+    x2,
+    xn,
+    h,
+    interval,
+    estimation,
+    latexString,
+) {
     if (interval > 3) {
-        const latexString = `\\scriptsize\\int_{${x0}}^{${xn}}f(x)dx\\approx\\frac{(${xn}-${x0})}{${h}}\\left[f(${x0})+2f(${x1})+\\cdots +2f(${x2})+f(${xn})\\right]`;
-
         return (
             <div className="Estimation">
                 <p>Formula</p>
@@ -31,8 +30,8 @@ function TrapezodialEstimation(func, xStart, xEnd, interval) {
             </div>
         );
     }
-
-    const latexString = `\\scriptsize\\int_{${x0}}^{${xn}}f(x)dx\\approx\\frac{(${xn}-${x0})}{${h}}\\left[f(${x0})+2f(${x1})+2f(${x2})+f(${xn})\\right]`;
+    let latex = latexString;
+    latex = `\\scriptsize\\int_{${x0}}^{${xn}}f(x)dx\\approx\\frac{(${xn}-${x0})}{${h}}\\left[f(${x0})+2f(${x1})+2f(${x2})+f(${xn})\\right]`;
 
     return (
         <div className="Estimation">
@@ -46,8 +45,92 @@ function TrapezodialEstimation(func, xStart, xEnd, interval) {
             <LaTex tex="\tiny\int_{a}^{b}f(x)dx\approx\frac{(b-a)}{2n}\left[f(x_{0})+2f(x_{1})+2f(x_{2})+\cdots +2f(x_{n-1})+f(x_{n})\right]" />
             <br />
             <p>Actual Estimation</p>
-            <LaTex tex={latexString} />
+            <LaTex tex={latex} />
         </div>
+    );
+}
+
+function PIString(
+    piAtStart,
+    func,
+    x0,
+    x1,
+    x2,
+    xn,
+    h,
+    interval,
+    estimation,
+    latexString,
+) {
+    if (piAtStart === true) {
+        return LatexString(
+            func,
+            x0,
+            x1,
+            x2,
+            xn,
+            h,
+            interval,
+            estimation,
+            latexString,
+        );
+    }
+    return LatexString(
+        func,
+        x0,
+        x1,
+        x2,
+        xn,
+        h,
+        interval,
+        estimation,
+        latexString,
+    );
+}
+
+function TrapezodialEstimation(func, xStart, xEnd, interval) {
+    const estimation = trapezoidal(func, xStart, xEnd, interval).toFixed(6);
+
+    const x0 = (xStart + 0).toFixed(0);
+    const xn = (xEnd + 0).toFixed(0);
+    const delta = (xEnd - xStart) / interval;
+    const h = 2 * interval;
+    const x1 = (xStart + delta).toFixed(1);
+    const x2 = (xEnd - delta).toFixed(1);
+
+    let latexString = `\\scriptsize\\int_{${x0}}^{${xn}}f(x)dx\\approx\\frac{(${xn}-${x0})}{${h}}\\left[f(${x0})+2f(${x1})+\\cdots +2f(${x2})+f(${xn})\\right]`;
+    let isPI = false;
+
+    if (xStart !== Math.PI && xEnd !== Math.PI) {
+        return LatexString(
+            func,
+            x0,
+            x1,
+            x2,
+            xn,
+            h,
+            interval,
+            estimation,
+            latexString,
+        );
+    }
+    if (xStart === Math.PI) {
+        latexString = `\\scriptsize\\int_{\\pi}^{${xn}}f(x)dx\\approx\\frac{(${xn}-\\pi)}{${h}}\\left[f(\\pi)+2f(${x1})+\\cdots +2f(${x2})+f(${xn})\\right]`;
+        isPI = true;
+    } else if (xEnd === Math.PI) {
+        latexString = `\\scriptsize\\int_{${x0}}^{\\pi}f(x)dx\\approx\\frac{(\\pi-${x0})}{${h}}\\left[f(${x0})+2f(${x1})+\\cdots +2f(${x2})+f(\\pi)\\right]`;
+    }
+    return PIString(
+        isPI,
+        func,
+        x0,
+        x1,
+        x2,
+        xn,
+        h,
+        interval,
+        estimation,
+        latexString,
     );
 }
 

--- a/src/components/calculator/TrapezoidalEstimation.jsx
+++ b/src/components/calculator/TrapezoidalEstimation.jsx
@@ -13,26 +13,10 @@ function LatexString(
     estimation,
     latexString,
 ) {
-    if (interval > 3) {
-        return (
-            <div className="Estimation">
-                <p>Formula</p>
-                <LaTex tex={func} />
-                <br />
-                <p>Estimation</p>
-                <LaTex tex={estimation} />
-                <br />
-                <p>Quadrature Function</p>
-                <LaTex tex="\tiny\int_{a}^{b}f(x)dx\approx\frac{(b-a)}{2n}\left[f(x_{0})+2f(x_{1})+2f(x_{2})+\cdots +2f(x_{n-1})+f(x_{n})\right]" />
-                <br />
-                <p>Actual Estimation</p>
-                <LaTex tex={latexString} />
-            </div>
-        );
-    }
     let latex = latexString;
-    latex = `\\scriptsize\\int_{${x0}}^{${xn}}f(x)dx\\approx\\frac{(${xn}-${x0})}{${h}}\\left[f(${x0})+2f(${x1})+2f(${x2})+f(${xn})\\right]`;
-
+    if (interval <= 3) {
+        latex = `\\scriptsize\\int_{${x0}}^{${xn}}f(x)dx\\approx\\frac{(${xn}-${x0})}{${h}}\\left[f(${x0})+2f(${x1})+2f(${x2})+f(${xn})\\right]`;
+    }
     return (
         <div className="Estimation">
             <p>Formula</p>


### PR DESCRIPTION
closing #23 

렌더링이 웹에서 이미지로뜨기에 테스팅은 수동으로 입력 변수를 변경하며
옳은 값이 출력되는지 확인했습니다.
다음은 제가 진행한 테스트중 일부입니다.

단항식, n이 3이하일경우:
<img width="308" alt="ex3" src="https://github.com/sfu-software-engineering-club/numerical-method-visualizer/assets/47872742/1d18f1b0-3612-49d4-b94d-61e1edc76a3d">
단항식, n이 3초과일경우:
<img width="310" alt="ex4" src="https://github.com/sfu-software-engineering-club/numerical-method-visualizer/assets/47872742/4ba2d56d-ade8-41bf-8ebd-b7979465e5db">

다항식, n이 3이하일경우:
<img width="296" alt="poly3" src="https://github.com/sfu-software-engineering-club/numerical-method-visualizer/assets/47872742/6485e7d2-d0bf-4c54-91f0-65d677810282">
다항식, n이 3초과일경우:
<img width="313" alt="poly4" src="https://github.com/sfu-software-engineering-club/numerical-method-visualizer/assets/47872742/525031de-a784-4271-a9c2-6147e2658f98">

a 가 π 이고 n 이 3이하일경우:
<img width="306" alt="piS3" src="https://github.com/sfu-software-engineering-club/numerical-method-visualizer/assets/47872742/d3e5cb18-ed1f-4513-9ec8-234a930d3ae0">
a 가 π 이고 n 이 3초과일경우:
<img width="307" alt="piS4" src="https://github.com/sfu-software-engineering-club/numerical-method-visualizer/assets/47872742/10611b6e-f7e1-4a09-981f-98cce401c461">

b가 π 이고 n 이 3이하일경우:
<img width="304" alt="piE3" src="https://github.com/sfu-software-engineering-club/numerical-method-visualizer/assets/47872742/da929a0d-3db5-4cda-8adc-08dd50d76eb5">

b가 π 이고 n 이 3초과일경우:
<img width="312" alt="piE4" src="https://github.com/sfu-software-engineering-club/numerical-method-visualizer/assets/47872742/6a04f781-2d60-4d13-b814-3a42c951c9c0">

